### PR TITLE
Player Initial Position

### DIFF
--- a/triple-dungeon/config.py
+++ b/triple-dungeon/config.py
@@ -48,7 +48,7 @@ class Enums(Enum):
     A simple class used for tracking different simple
     """
 
-    # Play Direction Enums
+    # Player Direction Enums
     RIGHT = 0
     LEFT = 1
     UP = 2

--- a/triple-dungeon/main.py
+++ b/triple-dungeon/main.py
@@ -49,28 +49,22 @@ class Game(arcade.Window):
         # Create the dungeon
         self.dungeon = Dungeon(0, 3)
 
-        # level = random.choice(self.dungeon.levelList)
-        level = self.dungeon.levels[1][1]
-
         # Set up the player, specifically placing it at these coordinates.
-        x, y = level.center()
-        self.player = Player(center_x=x, center_y=y)
+        self.player = Player()
         self.player.scale = 1
-
-        # Debug statement
-        print((level.x, level.y), level.center(), (self.player.center_x, self.player.center_y))
+        level = random.choice(self.dungeon.levelList)
+        self.player.center_x, self.player.center_y = level.center()
+        # x, y = level.center()
 
         # Setup viewport
-        self.view_bottom = x - (0.5 * Config.SCREEN_WIDTH)
-        self.view_left = y - (0.5 * Config.SCREEN_WIDTH)
+        self.view_bottom = self.player.center_x - (0.5 * Config.SCREEN_WIDTH) + 300
+        self.view_left = self.player.center_x - (0.5 * Config.SCREEN_WIDTH)
         arcade.set_viewport(self.view_left,
                             Config.SCREEN_WIDTH + self.view_left,
                             self.view_bottom,
                             Config.SCREEN_HEIGHT + self.view_bottom)
-        self.player.center_x, self.player.center_y = x, y
 
         # Create monsters
-        # This needs to be updated to comply with the new mobs.py code
         # self.enemy_list.append(Enemy("resources/images/monsters/ghost/ghost1.png", 200, 200, 4))
         # self.enemy_list.append(Enemy("resources/images/monsters/frog/frog1.png", 200, 1000, 4))
 
@@ -79,17 +73,22 @@ class Game(arcade.Window):
 
     def on_draw(self):
         """ Render the screen. """
+        try:
 
-        # Clear the screen to the background color
-        arcade.start_render()
+            # Clear the screen to the background color
+            arcade.start_render()
 
-        # Draw our sprites
-        self.dungeon.render()
-        self.player.draw()
-        self.enemy_list.draw()
+            # Draw our sprites
+            self.dungeon.render()
+            self.player.draw()
+            self.enemy_list.draw()
 
-        x, y = self.view_left + 50, self.view_bottom + 50
-        arcade.draw_text(str((self.player.center_x,  self.player.center_y)), x, y, arcade.color.WHITE, 15)
+            self.player.draw_hit_box()
+            x, y = self.player.center_x, self.player.center_y
+            arcade.draw_text(str((x, y)), x - 40, y + 50, arcade.color.WHITE, 15)
+        except Exception:
+            import traceback
+            traceback.print_exc()
 
     def on_key_press(self, key, modifiers):
         """Called whenever a key is pressed. """

--- a/triple-dungeon/main.py
+++ b/triple-dungeon/main.py
@@ -23,8 +23,6 @@ class Game(arcade.Window):
 
         # These are 'lists' that keep track of our sprites. Each sprite should
         # go into a list.
-        self.wall_list = None
-        self.floor_list = None
         self.enemy_list = None
         self.player = None
 
@@ -89,11 +87,9 @@ class Game(arcade.Window):
         self.dungeon.render()
         self.player.draw()
         self.enemy_list.draw()
-        self.wall_list.draw()
 
         x, y = self.view_left + 50, self.view_bottom + 50
         arcade.draw_text(str((self.player.center_x,  self.player.center_y)), x, y, arcade.color.WHITE, 15)
-        print('Here.')
 
     def on_key_press(self, key, modifiers):
         """Called whenever a key is pressed. """

--- a/triple-dungeon/main.py
+++ b/triple-dungeon/main.py
@@ -48,14 +48,28 @@ class Game(arcade.Window):
 
         self.enemy_list = arcade.SpriteList()
 
-        # Set up the player, specifically placing it at these coordinates.
-        self.player = Player()
-        self.player.scale = 1
-
         # Create the dungeon
         self.dungeon = Dungeon(0, 3)
 
-        self.player.center_x, self.player.center_y = random.choice(self.dungeon.levelList).center()
+        # level = random.choice(self.dungeon.levelList)
+        level = self.dungeon.levels[1][1]
+
+        # Set up the player, specifically placing it at these coordinates.
+        x, y = level.center()
+        self.player = Player(center_x=x, center_y=y)
+        self.player.scale = 1
+
+        # Debug statement
+        print((level.x, level.y), level.center(), (self.player.center_x, self.player.center_y))
+
+        # Setup viewport
+        self.view_bottom = x - (0.5 * Config.SCREEN_WIDTH)
+        self.view_left = y - (0.5 * Config.SCREEN_WIDTH)
+        arcade.set_viewport(self.view_left,
+                            Config.SCREEN_WIDTH + self.view_left,
+                            self.view_bottom,
+                            Config.SCREEN_HEIGHT + self.view_bottom)
+        self.player.center_x, self.player.center_y = x, y
 
         # Create monsters
         # This needs to be updated to comply with the new mobs.py code
@@ -77,8 +91,9 @@ class Game(arcade.Window):
         self.enemy_list.draw()
         self.wall_list.draw()
 
-        x, y = self.player.center_x, self.player.center_y + 100
-        arcade.draw_text(f"({x}, {y})", x, y, arcade.color.WHITE, 15)
+        x, y = self.view_left + 50, self.view_bottom + 50
+        arcade.draw_text(str((self.player.center_x,  self.player.center_y)), x, y, arcade.color.WHITE, 15)
+        print('Here.')
 
     def on_key_press(self, key, modifiers):
         """Called whenever a key is pressed. """

--- a/triple-dungeon/map.py
+++ b/triple-dungeon/map.py
@@ -144,15 +144,18 @@ class Level:
                     level.wallSprites.append(sprite)
 
         # Move everything into correct positions
-        level.floorSprites.move(Config.LEVEL_SIZE * level.x, Config.LEVEL_SIZE * level.y)
-        level.wallSprites.move(Config.LEVEL_SIZE * level.x, Config.LEVEL_SIZE * level.y)
+        level.floorSprites.move(*level.bottomLeft())
+        level.wallSprites.move(*level.bottomLeft())
 
         return level
 
-    def topleft(self) -> tuple:
+    def bottomLeft(self) -> tuple:
         """
-        :return:
+        Return the pixel bottom left corner of a Level.
+
+        :return: A tuple containing the X and Y coordinates of the level's bottom left corner.
         """
+        return Config.LEVEL_SIZE * self.x, Config.LEVEL_SIZE * self.y
 
     def center(self) -> tuple:
         """

--- a/triple-dungeon/map.py
+++ b/triple-dungeon/map.py
@@ -144,10 +144,15 @@ class Level:
                     level.wallSprites.append(sprite)
 
         # Move everything into correct positions
-        level.floorSprites.move(*level.center())
-        level.wallSprites.move(*level.center())
+        level.floorSprites.move(Config.LEVEL_SIZE * level.x, Config.LEVEL_SIZE * level.y)
+        level.wallSprites.move(Config.LEVEL_SIZE * level.x, Config.LEVEL_SIZE * level.y)
 
         return level
+
+    def topleft(self) -> tuple:
+        """
+        :return:
+        """
 
     def center(self) -> tuple:
         """

--- a/triple-dungeon/map.py
+++ b/triple-dungeon/map.py
@@ -142,8 +142,6 @@ class Level:
                     level.floorSprites.append(sprite)
                 elif 'wall' in tilePath:
                     level.wallSprites.append(sprite)
-                else:
-                    print(f'Could not handle Tile: {tilePath}')
 
         # Move everything into correct positions
         level.floorSprites.move(*level.center())
@@ -156,7 +154,7 @@ class Level:
         Returns the pixel center of the level.
         :return: A tuple containing the X and Y coordinates of the level's center
         """
-        return self.x * Config.LEVEL_SIZE, self.y * Config.LEVEL_SIZE
+        return int((self.x + 0.5) * Config.LEVEL_SIZE), int((self.y + 0.5) * Config.LEVEL_SIZE)
 
     def rotate_level(self, times_rotated):
         """


### PR DESCRIPTION
This is pretty minor, but it was just trying to fix player placement at the start. Players should now start at a random Level's center, and Levels should now start from 0,0 and expand up and to the right properly.

This issue was caused by the `Level` object depending on the `Level.center()` function, which it would dilate by. This would cause everything in the world to dilate by that amount, no matter what you did. Very confusing since I forgot that I used the method.