### PR TITLE
Performance Fixes

### DIFF
--- a/triple-dungeon/config.py
+++ b/triple-dungeon/config.py
@@ -42,6 +42,9 @@ class Config(object):
     BOTTOM_VIEWPORT_MARGIN = 50
     TOP_VIEWPORT_MARGIN = 100
 
+    # All debug statements and renderings should use this
+    DEBUG = True
+
 
 class Enums(Enum):
     """

--- a/triple-dungeon/main.py
+++ b/triple-dungeon/main.py
@@ -74,7 +74,7 @@ class Game(arcade.Window):
         self.bullet_list = arcade.SpriteList()
 
         # Create the dungeon
-        self.dungeon = Dungeon(0, 12)
+        self.dungeon = Dungeon(0, 8)
 
         # Set up the player, specifically placing it at these coordinates.
         self.player = Player()

--- a/triple-dungeon/main.py
+++ b/triple-dungeon/main.py
@@ -3,13 +3,34 @@ main.py
 The main class used to load the game.
 Holds the main game window, as well as manages basic functions for organizing the game.
 """
+import collections
 import random
+import time
 
 import arcade
 
 from config import Config
 from map import Dungeon
 from mobs import Player
+
+
+class FPSCounter:
+    def __init__(self):
+        self.time = time.perf_counter()
+        self.frame_times = collections.deque(maxlen=60)
+
+    def tick(self):
+        t1 = time.perf_counter()
+        dt = t1 - self.time
+        self.time = t1
+        self.frame_times.append(dt)
+
+    def get_fps(self):
+        total_time = sum(self.frame_times)
+        if total_time == 0:
+            return 0
+        else:
+            return len(self.frame_times) / sum(self.frame_times)
 
 
 class Game(arcade.Window):
@@ -45,9 +66,10 @@ class Game(arcade.Window):
         # Create the Sprite lists
 
         self.enemy_list = arcade.SpriteList()
+        self.fps = FPSCounter()
 
         # Create the dungeon
-        self.dungeon = Dungeon(0, 3)
+        self.dungeon = Dungeon(0, 5)
 
         # Set up the player, specifically placing it at these coordinates.
         self.player = Player()
@@ -74,7 +96,6 @@ class Game(arcade.Window):
     def on_draw(self):
         """ Render the screen. """
         try:
-
             # Clear the screen to the background color
             arcade.start_render()
 
@@ -86,6 +107,9 @@ class Game(arcade.Window):
             self.player.draw_hit_box()
             x, y = self.player.center_x, self.player.center_y
             arcade.draw_text(str((x, y)), x - 40, y + 50, arcade.color.WHITE, 15)
+            arcade.draw_text(f"FPS: {self.fps.get_fps():3.0f}", self.view_left + 50, self.view_bottom + 30,
+                             arcade.color.WHITE, 16)
+            self.fps.tick()
         except Exception:
             import traceback
             traceback.print_exc()

--- a/triple-dungeon/main.py
+++ b/triple-dungeon/main.py
@@ -74,7 +74,7 @@ class Game(arcade.Window):
         self.bullet_list = arcade.SpriteList()
 
         # Create the dungeon
-        self.dungeon = Dungeon(0, 5)
+        self.dungeon = Dungeon(0, 12)
 
         # Set up the player, specifically placing it at these coordinates.
         self.player = Player()
@@ -112,9 +112,9 @@ class Game(arcade.Window):
 
             self.player.draw_hit_box()
             x, y = self.player.center_x, self.player.center_y
-            arcade.draw_text(str((x, y)), x - 40, y + 50, arcade.color.WHITE, 15)
+            arcade.draw_text(str((x, y)), x - 40, y + 50, arcade.color.WHITE, 15, font_name='Arial')
             arcade.draw_text(f"FPS: {self.fps.get_fps():3.0f}", self.view_left + 50, self.view_bottom + 30,
-                             arcade.color.WHITE, 16)
+                             arcade.color.WHITE, 16, font_name='Arial')
             self.fps.tick()
         except Exception:
             import traceback

--- a/triple-dungeon/map.py
+++ b/triple-dungeon/map.py
@@ -32,8 +32,8 @@ class Dungeon(object):
         self.level_count = level_count
         self.size = size
 
-        self.floor_list = arcade.SpriteList()
-        self.wall_list = arcade.SpriteList()
+        self.floor_list = arcade.SpriteList(is_static=True)
+        self.wall_list = arcade.SpriteList(is_static=True)
 
         # center = Level.load_file(1, 1, 'resources/levels/map1/center.json')
         # side = Level.load_file(2, 1, 'resources/levels/map1/room.json')
@@ -48,10 +48,10 @@ class Dungeon(object):
         Simple one time function for getting all Wall sprites from all Levels.
         Used by the physics engine during game startup.
 
-        :return: A SpriteList containing all Sprites.
+        :return: A SpriteList containing all Wall (Collidable) Sprites.
         """
 
-        walls = arcade.SpriteList()
+        walls = arcade.SpriteList(is_static=True)
         walls.extend(
             list(chain.from_iterable(
                 chain.from_iterable([level.wallSprites for level in column if level is not None]) for column in
@@ -102,8 +102,8 @@ class Level:
         self.sprites = []
         self.structure = []
 
-        self.floorSprites = arcade.SpriteList()
-        self.wallSprites = arcade.SpriteList()
+        self.floorSprites = arcade.SpriteList(is_static=True)
+        self.wallSprites = arcade.SpriteList(is_static=True)
 
         # Tuples containing the Node positions of where walls, floor and entrances are.
         # All positions are generated based on the level's X and Y position, so that all points within


### PR DESCRIPTION
Mainly addresses concerns with how sprites are drawn. 

Changes:
- Adds a new `DEBUG` config line
- Floor and Wall SpriteLists now use `is_static`.
    - I have no idea if this helped performance, but everything hovers at 57-60fps right now, even with large Dungeons (size 9+), so I believe we're in the clear.
    - Keep this in mind if you want to move sprites around. It could be an easy way to break stuff.
- Adds a new FPS Counter class.
    - Tracks FPS and renders a little counter in the bottom left corner when `DEBUG` mode is enabled.